### PR TITLE
use default export, unpack values as needed, fixes #71

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -8,7 +8,7 @@ import DayToDaySnugget from '../DayToDayHungerSnugget/DayToDayHungerSnugget'
 import DonutChart from '../DonutChart/DonutChart'
 import counties from '../../fixtures/counties'
 import data from '../../fixtures/data'
-import { MEAL_PERIOD_DAYS } from '../../fixtures/constants'
+import constants from '../../fixtures/constants'
 import MapView from '../MapView/MapView'
 import { calcMealGap, getRemainingIncome } from './calculators'
 
@@ -74,12 +74,7 @@ export default class App extends React.Component {
   }
 
   getFoodSecurityStatus(individuals, wage, fips) {
-    const RATINGS = {
-      "secure": 4,
-      "moderately insecure": 3,
-      "highly insecure": 2,
-      "extremely insecure": 1
-    }
+    const { RATINGS } = constants
     const mealCost = data.costOfMeals[fips].cost_per_meal
     const income = getRemainingIncome(individuals, wage, fips)
     const canAfford = Math.round(income / mealCost)
@@ -160,6 +155,7 @@ export default class App extends React.Component {
     const options = counties.map(c => ({ value: c.fips, label: c.name }))
     const dropdownCounty = { value: this.state.selectedCounty.fips, label: this.state.selectedCounty.name }
     const dollarFormatter = (val) => ("$" + val)
+    const { MEAL_PERIOD_DAYS } = constants
     const totalMealsGoal = this.state.individuals * 3 * MEAL_PERIOD_DAYS
     const mealValues = [this.getMissingMeals(), totalMealsGoal]
     const { individuals, sliderWage, selectedCounty } = this.state

--- a/src/components/App/calculators.js
+++ b/src/components/App/calculators.js
@@ -1,5 +1,7 @@
 import { schoolMeals, costOfMeals, housing } from '../../fixtures/data'
-import { MEAL_PERIOD_DAYS } from '../../fixtures/constants'
+import constants from '../../fixtures/constants'
+
+const { MEAL_PERIOD_DAYS } = constants
 
 function snapCalculator(individuals, income, fips) {
   let limit, shelter, maxBenefit

--- a/src/fixtures/constants.js
+++ b/src/fixtures/constants.js
@@ -1,5 +1,15 @@
 const MEAL_PERIOD_DAYS = 37
 
-export default {
-  MEAL_PERIOD_DAYS,
+const RATINGS = {
+  "secure": 4,
+  "moderately insecure": 3,
+  "highly insecure": 2,
+  "extremely insecure": 1
 }
+
+const exports = {
+  MEAL_PERIOD_DAYS,
+  RATINGS
+}
+
+export default exports


### PR DESCRIPTION
Still a bit mysterious as to why this is necessary. Maybe because the calculators.js is exporting functions, whereas the constants are a number and an object. In any case, unpacking the values where they're needed fixes the problem.
